### PR TITLE
Swap to MakeDelegate wherever immediately obvious, update to 0.8.x

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -20,16 +20,9 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := hook
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))
 include $(CLEAR_VARS)
-LOCAL_MODULE := codegen_0_3_4
-LOCAL_EXPORT_C_INCLUDES := extern/codegen
-LOCAL_SRC_FILES := extern/libcodegen_0_3_4.so
-LOCAL_CPP_FEATURES += exceptions
-include $(PREBUILT_SHARED_LIBRARY)
-# Creating prebuilt for dependency: beatsaber-hook - version: 0.7.7
-include $(CLEAR_VARS)
-LOCAL_MODULE := beatsaber-hook_0_7_8
+LOCAL_MODULE := beatsaber-hook_0_8_0
 LOCAL_EXPORT_C_INCLUDES := extern/beatsaber-hook
-LOCAL_SRC_FILES := extern/libbeatsaber-hook_0_7_8.so
+LOCAL_SRC_FILES := extern/libbeatsaber-hook_0_8_0.so
 LOCAL_CPP_FEATURES += exceptions
 include $(PREBUILT_SHARED_LIBRARY)
 # Creating prebuilt for dependency: custom-types - version: 0.2.9
@@ -44,6 +37,19 @@ LOCAL_MODULE := modloader
 LOCAL_EXPORT_C_INCLUDES := extern/modloader
 LOCAL_SRC_FILES := extern/libmodloader.so
 include $(PREBUILT_SHARED_LIBRARY)
+# Creating prebuilt for dependency: codegen - version: 0.3.5
+include $(CLEAR_VARS)
+LOCAL_MODULE := codegen_0_3_5
+LOCAL_EXPORT_C_INCLUDES := extern/codegen
+LOCAL_SRC_FILES := extern/libcodegen_0_3_5.so
+LOCAL_CPP_FEATURES += exceptions
+include $(PREBUILT_SHARED_LIBRARY)
+# Creating prebuilt for dependency: beatsaber-hook - version: 0.8.1
+include $(CLEAR_VARS)
+LOCAL_MODULE := beatsaber-hook_0_8_2
+LOCAL_EXPORT_C_INCLUDES := extern/beatsaber-hook
+LOCAL_SRC_FILES := extern/libbeatsaber-hook_0_8_2.so
+include $(PREBUILT_SHARED_LIBRARY)
 
 # If you would like to use more shared libraries (such as custom UI, utils, or more) add them here, following the format above. # In addition, ensure that you add them to the shared library build below. 
 include $(CLEAR_VARS) 
@@ -52,8 +58,8 @@ LOCAL_SRC_FILES += $(call rwildcard,src/**,*.cpp)
 LOCAL_SRC_FILES += $(call rwildcard,extern/beatsaber-hook/src/inline-hook,*.cpp)
 LOCAL_SRC_FILES += $(call rwildcard,extern/beatsaber-hook/src/inline-hook,*.c)
 LOCAL_SHARED_LIBRARIES += modloader
-LOCAL_SHARED_LIBRARIES += beatsaber-hook_0_7_8
-LOCAL_SHARED_LIBRARIES += codegen_0_3_4
+LOCAL_SHARED_LIBRARIES += beatsaber-hook_0_8_2
+LOCAL_SHARED_LIBRARIES += codegen_0_3_5
 LOCAL_SHARED_LIBRARIES += custom-types
 LOCAL_LDLIBS += -llog 
 LOCAL_CFLAGS += -I"include" -I"shared" -I"./extern/libil2cpp/il2cpp/libil2cpp" -I"extern" -I"extern/codegen/include" -DVERSION='"0.2.0"'

--- a/qpm.json
+++ b/qpm.json
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "id": "beatsaber-hook",
-      "versionRange": "^0.7.8",
+      "versionRange": "^0.8.1",
       "additionalData": {
         "extraFiles": [
           "src/inline-hook"

--- a/src/BeatSaberUI.cpp
+++ b/src/BeatSaberUI.cpp
@@ -414,8 +414,8 @@ namespace QuestUI::BeatSaberUI {
         Button* incButton = ArrayUtil::Last(child->GetComponentsInChildren<Button*>());
         decButton->set_interactable(true);
         incButton->set_interactable(true);
-        decButton->get_onClick()->AddListener(il2cpp_utils::MakeAction<UnityAction>(il2cpp_functions::class_get_type(classof(UnityAction*)), setting, +[](IncrementSetting* setting){ setting->DecButtonPressed(); }));
-        incButton->get_onClick()->AddListener(il2cpp_utils::MakeAction<UnityAction>(il2cpp_functions::class_get_type(classof(UnityAction*)), setting, +[](IncrementSetting* setting){ setting->IncButtonPressed(); }));
+        decButton->get_onClick()->AddListener(il2cpp_utils::MakeDelegate<UnityAction*>(classof(UnityAction*), setting, +[](IncrementSetting* setting){ setting->DecButtonPressed(); }));
+        incButton->get_onClick()->AddListener(il2cpp_utils::MakeDelegate<UnityAction*>(classof(UnityAction*), setting, +[](IncrementSetting* setting){ setting->IncButtonPressed(); }));
         
         child->GetComponent<RectTransform*>()->set_sizeDelta(UnityEngine::Vector2(40, 0));
         TextMeshProUGUI* textMesh = gameObject->GetComponentInChildren<TextMeshProUGUI*>();
@@ -566,8 +566,7 @@ namespace QuestUI::BeatSaberUI {
         fieldView->SetText(il2cpp_utils::createcsstr(currentValue));
         fieldView->onValueChanged = InputFieldView::InputFieldChanged::New_ctor();
         if(onValueChange)
-            fieldView->onValueChanged->AddListener(il2cpp_utils::MakeAction<UnityAction_1<InputFieldView*>>(il2cpp_functions::class_get_type(classof(UnityAction_1<InputFieldView*>*)), onValueChange, +[](UnityAction_1<Il2CppString*>* onValueChange, InputFieldView* fieldView) { onValueChange->Invoke(fieldView->get_text()); }));
+            fieldView->onValueChanged->AddListener(il2cpp_utils::MakeDelegate<UnityAction_1<InputFieldView*>*>(classof(UnityAction_1<InputFieldView*>*), onValueChange, +[](UnityAction_1<Il2CppString*>* onValueChange, InputFieldView* fieldView) { onValueChange->Invoke(fieldView->get_text()); }));
         return fieldView;
     }
-
 }

--- a/src/CustomTypes/Components/FlowCoordinators/ModSettingsFlowCoordinator.cpp
+++ b/src/CustomTypes/Components/FlowCoordinators/ModSettingsFlowCoordinator.cpp
@@ -67,7 +67,7 @@ void QuestUI::ModSettingsFlowCoordinator::DidActivate(bool firstActivation, bool
         }
         if(!ModSettingsButtonsViewController)
             ModSettingsButtonsViewController = BeatSaberUI::CreateViewController<QuestUI::ModSettingsButtonsViewController*>();
-        ModSettingsButtonsViewController->add_openModSettings(il2cpp_utils::MakeAction<System::Action_1<QuestUI::ModSettingsButtonClickData*>>(il2cpp_functions::class_get_type(classof(System::Action_1<QuestUI::ModSettingsButtonClickData*>*)), this, OnOpenModSettings));
+        ModSettingsButtonsViewController->add_openModSettings(il2cpp_utils::MakeDelegate<System::Action_1<QuestUI::ModSettingsButtonClickData*>*>(classof(System::Action_1<QuestUI::ModSettingsButtonClickData*>*), this, OnOpenModSettings));
         ProvideInitialViewControllers(ModSettingsButtonsViewController, nullptr, nullptr, nullptr, nullptr);
         ActiveViewController = ModSettingsButtonsViewController;
     }

--- a/src/CustomTypes/Components/ViewControllers/ModSettingsButtonsViewController.cpp
+++ b/src/CustomTypes/Components/ViewControllers/ModSettingsButtonsViewController.cpp
@@ -33,7 +33,7 @@ void QuestUI::ModSettingsButtonsViewController::DidActivate(bool firstActivation
         layoutGroup->set_childAlignment(UnityEngine::TextAnchor::MiddleCenter);
         UnityEngine::RectTransform* rectTransform = layoutGroup->GetComponent<UnityEngine::RectTransform*>();
         for(ModSettingsInfos::ModSettingsInfo& info : ModSettingsInfos::get()) {
-            BeatSaberUI::CreateUIButton(rectTransform, info.modInfo.id, il2cpp_utils::MakeAction<UnityEngine::Events::UnityAction>(il2cpp_functions::class_get_type(classof(UnityEngine::Events::UnityAction*)), *il2cpp_utils::New<QuestUI::ModSettingsButtonClickData*>(classof(QuestUI::ModSettingsButtonClickData*), this, (void*)&info), OnModSettingsButtonClick));
+            BeatSaberUI::CreateUIButton(rectTransform, info.modInfo.id, il2cpp_utils::MakeDelegate<UnityEngine::Events::UnityAction*>(classof(UnityEngine::Events::UnityAction*), CRASH_UNLESS(il2cpp_utils::New<QuestUI::ModSettingsButtonClickData*>(classof(QuestUI::ModSettingsButtonClickData*), this, (void*)&info)), OnModSettingsButtonClick));
         }
     }
 }

--- a/src/QuestUI.cpp
+++ b/src/QuestUI.cpp
@@ -53,7 +53,7 @@ MAKE_HOOK_OFFSETLESS(OptionsViewController_DidActivate, void, GlobalNamespace::O
             UnityEngine::Transform* AvatarParent = self->get_transform()->Find(il2cpp_utils::createcsstr("Wrapper"));
             button->get_transform()->SetParent(AvatarParent, false);
             button->get_transform()->SetAsFirstSibling();
-            button->get_onClick()->AddListener(il2cpp_utils::MakeAction<UnityEngine::Events::UnityAction>(il2cpp_functions::class_get_type(classof(UnityEngine::Events::UnityAction*)), (Il2CppObject*)nullptr, OnMenuModSettingsButtonClick));
+            button->get_onClick()->AddListener(il2cpp_utils::MakeDelegate<UnityEngine::Events::UnityAction*>(classof(UnityEngine::Events::UnityAction*), (Il2CppObject*)nullptr, OnMenuModSettingsButtonClick));
             
             UnityEngine::Object::Destroy(button->GetComponentInChildren<Polyglot::LocalizedTextMeshProUGUI*>());
 


### PR DESCRIPTION
Pretty simple PR, I just swapped out all of the uses of `MakeAction` to `MakeDelegate`, it compiles fine after a qpm restore.
bs-hook 0.8.0 is still required by latest codegen, hence the existence of it in the Android.mk