### PR TITLE
SpriteToFile mismatched texture size crash fix

### DIFF
--- a/src/BeatSaberUI.cpp
+++ b/src/BeatSaberUI.cpp
@@ -319,7 +319,7 @@ namespace QuestUI::BeatSaberUI {
         Array<uint8_t>* bytes = il2cpp_utils::vectorToArray(data);
         Texture2D* texture = Texture2D::New_ctor(width, height, TextureFormat::RGBA32, false, false);
         if (ImageConversion::LoadImage(texture, bytes, false))
-            return Sprite::Create(texture, UnityEngine::Rect(0.0f, 0.0f, (float)width, (float)height), UnityEngine::Vector2(0.5f,0.5f), 1024.0f, 1u, SpriteMeshType::FullRect, UnityEngine::Vector4(0.0f, 0.0f, 0.0f, 0.0f), false);
+            return Sprite::Create(texture, UnityEngine::Rect(0.0f, 0.0f, (float)texture->get_width(), (float)texture->get_height()), UnityEngine::Vector2(0.5f,0.5f), 1024.0f, 1u, SpriteMeshType::FullRect, UnityEngine::Vector4(0.0f, 0.0f, 0.0f, 0.0f), false);
         return nullptr;
     }
 


### PR DESCRIPTION
This fixes a crash that happens when the size you give the method doesn't match up with the size of the texture, then crashing the game