### PR TITLE
Removed set_prefferedHeight

### DIFF
--- a/src/BeatSaberUI.cpp
+++ b/src/BeatSaberUI.cpp
@@ -989,7 +989,6 @@ namespace QuestUI::BeatSaberUI {
 
         auto layoutelem = content->AddComponent<LayoutElement*>();
         layoutelem->set_preferredWidth(width - 10.0f);
-        layoutelem->set_preferredHeight(height);
 
         static auto name = il2cpp_utils::createcsstr("QuestUICreateScrollableModalContainer", il2cpp_utils::StringType::Manual);
 


### PR DESCRIPTION
setting the preferred height is not needed at all, and just adds unnecesary scroll if the container is empty