### PR TITLE
Add set_interactable to button creation

### DIFF
--- a/src/BeatSaberUI.cpp
+++ b/src/BeatSaberUI.cpp
@@ -357,7 +357,9 @@ namespace QuestUI::BeatSaberUI {
         HorizontalLayoutGroup* horiztonalLayoutGroup = button->GetComponentInChildren<HorizontalLayoutGroup*>();
         if (horiztonalLayoutGroup != nullptr)
             externalComponents->Add(horiztonalLayoutGroup);
-            
+        
+        // if the original button was for some reason not interactable, now it will be
+        button->set_interactable(true);
         return button;
     }
 


### PR DESCRIPTION
pinkcore disables the play button, and having this not be done makes copied buttons not interactable, forcing them to be interactable at creation fixes that issue