### PR TITLE
Fix issue with which object is cloned for toggles

### DIFF
--- a/src/BeatSaberUI.cpp
+++ b/src/BeatSaberUI.cpp
@@ -791,7 +791,7 @@ namespace QuestUI::BeatSaberUI {
         static WeakPtrGO<GameObject> toggleCopy;
         if (!toggleCopy) {
             auto foundToggle = Resources::FindObjectsOfTypeAll<Toggle*>().FirstOrDefault([](auto x) { return x->get_transform()->get_parent()->get_gameObject()->get_name() == "Fullscreen"; });
-            toggleCopy = foundToggle ? foundToggle->get_gameObject() : nullptr;
+            toggleCopy = foundToggle ? foundToggle->get_transform()->get_parent()->get_gameObject() : nullptr;
         }
 
 


### PR DESCRIPTION
 - fix issue introduced in previous PR that made things use ArrayW.First