### PR TITLE
Add basic leaderboard support

### DIFF
--- a/shared/BeatSaberUI.hpp
+++ b/shared/BeatSaberUI.hpp
@@ -14,6 +14,7 @@
 #include "CustomTypes/Components/ModalColorPicker.hpp"
 #include "CustomTypes/Components/ClickableText.hpp"
 #include "CustomTypes/Components/ClickableImage.hpp"
+#include "CustomTypes/Components/LeaderboardComponent.hpp"
 
 #include "GlobalNamespace/MainFlowCoordinator.hpp"
 #include "GlobalNamespace/GameplayModifierToggle.hpp"
@@ -1073,5 +1074,14 @@ namespace QuestUI::BeatSaberUI {
     requires(!std::is_convertible_v<T, UnityEngine::Transform*>)
     inline QuestUI::CustomTextSegmentedControlData* CreateTextSegmentedControl(T parent, TArgs...args) {
         return CreateTextSegmentedControl(parent->get_transform(), args...);
+    }
+
+    /// @brief Creates a LeaderboardTableView component for use with custom leaderboards with or without the use of LeaderboardCore.
+    /// @param parent What you parent the leaderboard to
+    /// @return The created Leaderboard component
+    template<HasTransform T, typename ...TArgs>
+    requires(!std::is_convertible_v<T, UnityEngine::Transform*>)
+    QuestUI::LeaderboardComponent* CreateLeaderboard(T parent, TArgs...args) {
+        return CreateLeaderboard(parent->get_transform(), args...);
     }
 }

--- a/shared/CustomTypes/Components/LeaderboardComponent.hpp
+++ b/shared/CustomTypes/Components/LeaderboardComponent.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "UnityEngine/MonoBehaviour.hpp"
+#include "UnityEngine/Component.hpp"
+#include "custom-types/shared/macros.hpp"
+
+#include <vector>
+
+DECLARE_CLASS_CODEGEN(QuestUI, LeaderboardComponent, UnityEngine::MonoBehaviour,
+
+private:
+
+    std::vector<UnityEngine::Component*> components;
+
+public:
+    template<class T = UnityEngine::Component*>
+    T Get() {
+        return (T)GetByType(csTypeOf(T));
+    }
+
+    DECLARE_INSTANCE_METHOD(void, Add, UnityEngine::Component* component);
+    DECLARE_INSTANCE_METHOD(UnityEngine::Component*, GetByType, Il2CppReflectionType* type);
+
+    DECLARE_DEFAULT_CTOR();
+
+    DECLARE_SIMPLE_DTOR();
+)

--- a/src/BeatSaberUI.cpp
+++ b/src/BeatSaberUI.cpp
@@ -1861,8 +1861,12 @@ namespace QuestUI::BeatSaberUI {
         return CreateTextSegmentedControl(parent, {0, 0}, {80, 10}, values, onCellWithIdxClicked);
     }
 
-        QuestUI::CustomTextSegmentedControlData* CreateTextSegmentedControl(UnityEngine::Transform* parent, std::function<void(int)> onCellWithIdxClicked)
+    QuestUI::CustomTextSegmentedControlData* CreateTextSegmentedControl(UnityEngine::Transform* parent, std::function<void(int)> onCellWithIdxClicked)
     {
         return CreateTextSegmentedControl(parent, {0, 0}, {80, 10}, ArrayW<StringW>(static_cast<il2cpp_array_size_t>(0)), onCellWithIdxClicked);
+    }
+
+    QuestUI::LeaderboardComponent* CreateLeaderboard(UnityEngine::Transform* parent, UnityEngine::Vector3 position) {
+        return CreateLeaderboard(parent, position);
     }
 }

--- a/src/CustomTypes/Components/LeaderboardComponent.cpp
+++ b/src/CustomTypes/Components/LeaderboardComponent.cpp
@@ -1,0 +1,19 @@
+
+#include "CustomTypes/Components/LeaderboardComponent.hpp"
+
+DEFINE_TYPE(QuestUI, LeaderboardComponent)
+
+void QuestUI::LeaderboardComponent::Add(UnityEngine::Component* component) {
+    components.push_back(component);
+}
+
+UnityEngine::Component* QuestUI::LeaderboardComponent::GetByType(Il2CppReflectionType *type) {
+    if (!type) return nullptr;
+    Il2CppClass* clazz = il2cpp_functions::class_from_system_type(type);
+    for(UnityEngine::Component* component : components)
+    {
+        if (il2cpp_functions::class_is_assignable_from(clazz, il2cpp_functions::object_get_class(component)))
+            return component;
+    }
+    return nullptr;
+}


### PR DESCRIPTION
As the PR name suggests, this adds very basic support for the BSML tag `<leaderboard />` to QuestUI. It's currently untested, but I plan to do so asap. (yell at me if I haven't gotten to it yet.)