### PR TITLE
Remove strict class requirements + flow coord overloads.

### DIFF
--- a/shared/QuestUI.hpp
+++ b/shared/QuestUI.hpp
@@ -61,19 +61,19 @@ namespace QuestUI {
                 RegisterModSettings(modInfo, false, modInfo.id, csTypeOf(T), Type::FLOW_COORDINATOR);
             }
 
-            template<class T = HMUI::ViewController*>
+            template<class T>
             static void RegisterMainMenuModSettingsViewController(ModInfo modInfo, std::string title, bool showModInfo = true, DidActivateEvent didActivateEvent = nullptr) {
                 static_assert(std::is_convertible<T, HMUI::ViewController*>());
                 RegisterMainMenuModSettings(modInfo, showModInfo, title, csTypeOf(T), Type::VIEW_CONTROLLER, didActivateEvent);
             }
             
-            template<class T = HMUI::ViewController*>
+            template<class T>
             static void RegisterMainMenuModSettingsViewController(ModInfo modInfo, std::string title, DidActivateEvent didActivateEvent) {
                 static_assert(std::is_convertible<T, HMUI::ViewController*>());
                 RegisterMainMenuModSettingsViewController<T>(modInfo, title, true, didActivateEvent);
             }
 
-            template<class T = HMUI::ViewController*>
+            template<class T>
             static void RegisterMainMenuModSettingsViewController(ModInfo modInfo, DidActivateEvent didActivateEvent = nullptr) {
                 static_assert(std::is_convertible<T, HMUI::ViewController*>());
                 RegisterMainMenuModSettingsViewController<T>(modInfo, modInfo.id, true, didActivateEvent);

--- a/shared/QuestUI.hpp
+++ b/shared/QuestUI.hpp
@@ -84,6 +84,12 @@ namespace QuestUI {
                 static_assert(std::is_convertible<T, HMUI::FlowCoordinator*>());
                 RegisterMainMenuModSettings(modInfo, false, modInfo.id, csTypeOf(T), Type::FLOW_COORDINATOR);
             }
+        
+            template<class T>
+            static void RegisterMainMenuModSettingsFlowCoordinator(ModInfo modInfo, std::string title, bool showModInfo = false) {
+                static_assert(std::is_convertible<T, HMUI::FlowCoordinator*>());
+                RegisterMainMenuModSettings(modInfo, showModInfo, title, csTypeOf(T), Type::FLOW_COORDINATOR);
+            }
 
             /// @brief Register a GameplaySetupMenu type for usage within the left menu
             /// @tparam T the type to register


### PR DESCRIPTION
T might be a derivative of HMUI::ViewController + adds overloads for flow coordinators - This allows people to change the button text (`title`) ect when a flowcoordinator is used.