### PR TITLE
Only clear view controllers / flow coordinators on soft restart

### DIFF
--- a/src/CustomTypes/Components/FlowCoordinators/ModSettingsFlowCoordinator.cpp
+++ b/src/CustomTypes/Components/FlowCoordinators/ModSettingsFlowCoordinator.cpp
@@ -49,10 +49,6 @@ void QuestUI::ModSettingsFlowCoordinator::OnOpenModSettings(ModSettingsInfos::Mo
 
 void QuestUI::ModSettingsFlowCoordinator::DidActivate(bool firstActivation, bool addedToHierarchy, bool screenSystemEnabling) {
     if(firstActivation) {
-        for(ModSettingsInfos::ModSettingsInfo& info : ModSettingsInfos::get()) {
-            info.viewController = nullptr;
-            info.flowCoordinator = nullptr;
-        }
         static ConstString modSettingsName("Mod Settings");
         SetTitle(modSettingsName, ViewController::AnimationType::Out);
         showBackButton = true;

--- a/src/CustomTypes/Components/ViewControllers/MainMenuModSettingsViewController.cpp
+++ b/src/CustomTypes/Components/ViewControllers/MainMenuModSettingsViewController.cpp
@@ -56,21 +56,6 @@ namespace QuestUI
     {
         getLogger().info("MainMenuModSettingsViewController DidActivate %d %d", firstActivation, addedToHierarchy); 
         if (!firstActivation) return;
-        for (auto& info : ModSettingsInfos::get()) {
-            //if (info.location & Register::MenuLocation::MainMenu) { just to be safe clear all
-                switch (info.type)
-                {
-                    case Register::Type::VIEW_CONTROLLER: {
-                        info.viewController = nullptr;
-                        break;
-                    }
-                    case Register::Type::FLOW_COORDINATOR: {
-                        info.flowCoordinator = nullptr;
-                        break;
-                    }
-                }
-            //}
-        }
 
         float blackness = 0.0f;
         AddHeader(get_transform(), "Mods", {35, 14}, {-7.5, 30}, {blackness, blackness, blackness, 0.5f}, {blackness, blackness, blackness, 0.5f}, 10.0f);


### PR DESCRIPTION
this way the modsetting infos don't get cleared more than once causing repeated creation of the same types. 

also lets me do cool stuff in one of my mods so that's a plus