### PR TITLE
TextSegmentedControl fix

### DIFF
--- a/src/BeatSaberUI.cpp
+++ b/src/BeatSaberUI.cpp
@@ -1825,7 +1825,7 @@ namespace QuestUI::BeatSaberUI {
         static SafePtrUnity<TextSegmentedControl> segmentedControlTemplate;
         if (!segmentedControlTemplate)
             segmentedControlTemplate = Resources::FindObjectsOfTypeAll<HMUI::TextSegmentedControl*>().FirstOrDefault([](auto x){
-                return x->get_name() != "TextSegmentedControl" ? false : true;
+                return x->get_name() == "TextSegmentedControl";
         });
 
         auto segmentedControlObj = Object::Instantiate(segmentedControlTemplate->get_gameObject(), parent, false);

--- a/src/BeatSaberUI.cpp
+++ b/src/BeatSaberUI.cpp
@@ -1824,12 +1824,8 @@ namespace QuestUI::BeatSaberUI {
     {
         static SafePtrUnity<TextSegmentedControl> segmentedControlTemplate;
         if (!segmentedControlTemplate)
-            segmentedControlTemplate = Resources::FindObjectsOfTypeAll<HMUI::TextSegmentedControl*>().First([](auto x){
-            if (x->get_name() != "TextSegmentedControl") return false;
-            auto parent = x->get_transform()->get_parent();
-            if (!parent) return false;
-            auto parentName = parent->get_name();
-            return parentName == "GameplaySetupViewController" || parentName == "BaseGameplaySetupWrapper";
+            segmentedControlTemplate = Resources::FindObjectsOfTypeAll<HMUI::TextSegmentedControl*>().FirstOrDefault([](auto x){
+                return x->get_name() != "TextSegmentedControl" ? false : true;
         });
 
         auto segmentedControlObj = Object::Instantiate(segmentedControlTemplate->get_gameObject(), parent, false);


### PR DESCRIPTION
It seems not looking for a specific parent fixes the problem.  looking for an instance with a different name can cause all sorts of whack to happen with the size/scale of the textsegmentedcontrol